### PR TITLE
added webpack dev proxy

### DIFF
--- a/webpack.dev.babel.js
+++ b/webpack.dev.babel.js
@@ -35,7 +35,11 @@ export default {
     contentBase: resolve(__dirname, 'dist'),
     publicPath: '/',
     historyApiFallback: true,
-    headers: { 'Access-Control-Allow-Origin': '*' }
+    proxy: {
+      '/api/**': {
+        target: 'http://localhost:3000', secure: false
+      },
+    }
   },
 
   module: {


### PR DESCRIPTION
- allows the webpack dev server to proxy the api (when api server is running on `localhost:3000`)

NOTE: I wasn't able to fully test this without api keys, but the node server was receiving requests from the react app in dev mode (those requests just failed because I don't have keys for the flight api). 